### PR TITLE
Load routes when application booted

### DIFF
--- a/src/FilamentCmsServiceProvider.php
+++ b/src/FilamentCmsServiceProvider.php
@@ -92,7 +92,9 @@ class FilamentCmsServiceProvider extends ServiceProvider
 
     protected function bootRoutes(): self
     {
-        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        $this->app->booted(function (): void {
+            $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        });
 
         return $this;
     }

--- a/src/Models/FilamentCmsBlog.php
+++ b/src/Models/FilamentCmsBlog.php
@@ -46,7 +46,7 @@ class FilamentCmsBlog extends Model implements Sitemapable
 
             /** @var string $defaultMultiLang */
             $defaultMultiLang = config('filament-cms.multi_language_default', 'en');
-            
+
             foreach ($this->slug as $lang => $slug) {
                 $slug = str($slug)->prepend('blog/')->toString();
 


### PR DESCRIPTION
This makes it possible to hard-code or overwrite routes in your Laravel application, as the Filament CMS routes now load after the normal application routes have been loaded.